### PR TITLE
Fix 'no-color' flag for validate executor

### DIFF
--- a/packages/terraform/src/executors/validate/executor.ts
+++ b/packages/terraform/src/executors/validate/executor.ts
@@ -13,6 +13,6 @@ export default async function runExecutor(
 function toCmdOptions(options: ValidateExecutorSchema): string[] {
   return [
     ...(options.json !== undefined ? [`-json`]: []),
-    ...(options.noColor !== undefined ? [`-noColor`]: []),
+    ...(options.noColor !== undefined ? [`-no-color`]: []),
   ]
 }


### PR DESCRIPTION
Small typo fix for mapping of the `-no-color` flag for the `terraform validate` command. The other commands are already correct.