### PR TITLE
Allowed Exit Codes

### DIFF
--- a/packages/terraform/src/executors/apply/executor.ts
+++ b/packages/terraform/src/executors/apply/executor.ts
@@ -7,7 +7,7 @@ export default async function runExecutor(
   context: ExecutorContext,
 ) {
   const cmdopt = ["-input=false", "-auto-approve", ...toCmdOptions(options)]
-  return runTfCommand(context, "apply", cmdopt)
+  return runTfCommand(context, "apply", cmdopt, options.allowedExitCodes)
 }
 
 function toCmdOptions(options: ApplyExecutorSchema): string[] {

--- a/packages/terraform/src/executors/apply/schema.d.ts
+++ b/packages/terraform/src/executors/apply/schema.d.ts
@@ -6,4 +6,5 @@ export interface ApplyExecutorSchema {
   lockTimeout?: string
   noColor?: boolean
   parallelism?: number
+  allowedExitCodes?: number[]
 }

--- a/packages/terraform/src/executors/apply/schema.json
+++ b/packages/terraform/src/executors/apply/schema.json
@@ -5,6 +5,13 @@
   "title": "Apply executor",
   "description": "",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "allowedExitCodes": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      }
+    }
+  },
   "required": []
 }

--- a/packages/terraform/src/executors/fmt/executor.ts
+++ b/packages/terraform/src/executors/fmt/executor.ts
@@ -7,7 +7,7 @@ export default async function runExecutor(
   context: ExecutorContext,
 ) {
   const cmdopt = toCmdOptions(options)
-  return runTfCommand(context, "fmt", cmdopt)
+  return runTfCommand(context, "fmt", cmdopt, options.allowedExitCodes)
 }
 
 function toCmdOptions(options: FmtExecutorSchema): string[] {

--- a/packages/terraform/src/executors/fmt/schema.d.ts
+++ b/packages/terraform/src/executors/fmt/schema.d.ts
@@ -4,4 +4,5 @@ export interface FmtExecutorSchema {
   diff?: boolean
   check?: boolean
   recursive?: boolean
+  allowedExitCodes?: number[]
 }

--- a/packages/terraform/src/executors/fmt/schema.json
+++ b/packages/terraform/src/executors/fmt/schema.json
@@ -5,6 +5,13 @@
   "title": "Fmt executor",
   "description": "The terraform fmt executor is used to rewrite Terraform configuration files to a canonical format and style.",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "allowedExitCodes": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      }
+    }
+  },
   "required": []
 }

--- a/packages/terraform/src/executors/init/executor.ts
+++ b/packages/terraform/src/executors/init/executor.ts
@@ -7,7 +7,7 @@ export default async function runExecutor(
   context: ExecutorContext,
 ) {
   const cmdopt = ["-input=false", ...toCmdOptions(options)]
-  return runTfCommand(context, "init", cmdopt)
+  return runTfCommand(context, "init", cmdopt, options.allowedExitCodes)
 }
 
 function toCmdOptions(options: InitExecutorSchema ): string[] {

--- a/packages/terraform/src/executors/init/schema.d.ts
+++ b/packages/terraform/src/executors/init/schema.d.ts
@@ -2,6 +2,7 @@ export interface InitExecutorSchema {
   lock?: boolean
   lockTimeout?: string
   upgrade?: boolean
+  allowedExitCodes?: number[]
 }
 
 

--- a/packages/terraform/src/executors/init/schema.json
+++ b/packages/terraform/src/executors/init/schema.json
@@ -5,6 +5,13 @@
   "title": "Init executor",
   "description": "",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "allowedExitCodes": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      }
+    }
+  },
   "required": []
 }

--- a/packages/terraform/src/executors/plan/executor.ts
+++ b/packages/terraform/src/executors/plan/executor.ts
@@ -7,7 +7,7 @@ export default async function runExecutor(
   context: ExecutorContext,
 ) {
   const cmdopt = ["-input=false", ...toCmdOptions(options)]
-  return runTfCommand(context, "plan", cmdopt)
+  return runTfCommand(context, "plan", cmdopt, options.allowedExitCodes)
 }
 
 function toCmdOptions(options: PlanExecutorSchema ): string[] {

--- a/packages/terraform/src/executors/plan/schema.d.ts
+++ b/packages/terraform/src/executors/plan/schema.d.ts
@@ -12,4 +12,5 @@ export interface PlanExecutorSchema {
   noColor?: boolean
   out?: string
   parallelism?: number
+  allowedExitCodes?: number[]
 }

--- a/packages/terraform/src/executors/plan/schema.json
+++ b/packages/terraform/src/executors/plan/schema.json
@@ -5,6 +5,13 @@
   "title": "Plan executor",
   "description": "The plan executor creates an execution plan, which lets you preview the changes that Terraform plans to make to your infrastructure.",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "allowedExitCodes": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      }
+    }
+  },
   "required": []
 }

--- a/packages/terraform/src/executors/validate/executor.ts
+++ b/packages/terraform/src/executors/validate/executor.ts
@@ -7,7 +7,7 @@ export default async function runExecutor(
   context: ExecutorContext,
 ) {
   const cmdopt = toCmdOptions(options)
-  return runTfCommand(context, "validate", cmdopt)
+  return runTfCommand(context, "validate", cmdopt, options.allowedExitCodes)
 }
 
 function toCmdOptions(options: ValidateExecutorSchema): string[] {

--- a/packages/terraform/src/executors/validate/schema.d.ts
+++ b/packages/terraform/src/executors/validate/schema.d.ts
@@ -1,4 +1,5 @@
 export interface ValidateExecutorSchema {
   json?: boolean
   noColor?: boolean
+  allowedExitCodes?: number[]
 }

--- a/packages/terraform/src/executors/validate/schema.json
+++ b/packages/terraform/src/executors/validate/schema.json
@@ -5,6 +5,13 @@
   "title": "Validate executor",
   "description": "Runs static checks analysis.",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "allowedExitCodes": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      }
+    }
+  },
   "required": []
 }

--- a/packages/terraform/src/utils/run-tf-command.helper.ts
+++ b/packages/terraform/src/utils/run-tf-command.helper.ts
@@ -5,6 +5,7 @@ export function runTfCommand(
   context: ExecutorContext,
   command: 'init' | 'plan' | 'fmt' | 'validate' | 'apply',
   params: string[],
+  allowedExitCodes: number[] = [0],
 ): { success: boolean } {
   const cwd = context?.projectsConfigurations?.projects[context.projectName]?.sourceRoot || process.cwd()
 
@@ -17,6 +18,8 @@ export function runTfCommand(
     return { success: true }
   } catch (e) {
     console.error(`Failed to execute command: ${execute}`, e)
-    return { success: false }
+    // we can access error code as the error object will contain entire object from:
+    // https://nodejs.org/api/child_process.html#child_processspawnsynccommand-args-options
+    return { success: allowedExitCodes.includes(e.status) }
   }
 }


### PR DESCRIPTION
Closes #109 

Additional functionality to specify allowed exit codes as per the documentation https://developer.hashicorp.com/terraform/cli/commands/plan#detailed-exitcode an exit code of 2 means `Succeeded with non-empty diff (changes present)`

This PR is backwards compatible but allows the executor to specify an array of allowed exit codes e.g.
`npx nx plan project --allowedExitCodes=0,2` (this handles the case in the issue #109)