### PR TITLE
Add `-var` and `-var-file` support to `apply`

### DIFF
--- a/packages/terraform/src/executors/apply/executor.ts
+++ b/packages/terraform/src/executors/apply/executor.ts
@@ -18,9 +18,9 @@ function toCmdOptions(options: ApplyExecutorSchema): string[] {
     ...(options.lockTimeout !== undefined ? [`-lock-timeout=${options.lockTimeout}`] : []), 
     ...(options.noColor !== undefined ? ['-no-color'] : []),
     ...(options.parallelism !== undefined ? [`-parallelism=${options.parallelism}`] : []),
-    ...(options.planFile !== undefined ? [`${options.planFile}`] : []),
     ...(options.var !== undefined ? Object.entries(options.var).map(([k,v]) => `-var='${k}=${v}'`) : []),
     ...(options.varFile !== undefined ? [`-var-file='${options.varFile}'`] : []),
+    ...(options.planFile !== undefined ? [`${options.planFile}`] : []),
   ]
 }
 

--- a/packages/terraform/src/executors/apply/executor.ts
+++ b/packages/terraform/src/executors/apply/executor.ts
@@ -20,7 +20,7 @@ function toCmdOptions(options: ApplyExecutorSchema): string[] {
     ...(options.parallelism !== undefined ? [`-parallelism=${options.parallelism}`] : []),
     ...(options.planFile !== undefined ? [`${options.planFile}`] : []),
     ...(options.var !== undefined ? Object.entries(options.var).map(([k,v]) => `-var='${k}=${v}'`) : []),
-    ...(options.varFile !== undefined ? [`-var-file=${options.varFile}`] : []),
+    ...(options.varFile !== undefined ? [`-var-file='${options.varFile}'`] : []),
   ]
 }
 

--- a/packages/terraform/src/executors/apply/executor.ts
+++ b/packages/terraform/src/executors/apply/executor.ts
@@ -19,6 +19,8 @@ function toCmdOptions(options: ApplyExecutorSchema): string[] {
     ...(options.noColor !== undefined ? ['-no-color'] : []),
     ...(options.parallelism !== undefined ? [`-parallelism=${options.parallelism}`] : []),
     ...(options.planFile !== undefined ? [`${options.planFile}`] : []),
+    ...(options.var !== undefined ? Object.entries(options.var).map(([k,v]) => `-var='${k}=${v}'`) : []),
+    ...(options.varFile !== undefined ? [`-var-file=${options.varFile}`] : []),
   ]
 }
 

--- a/packages/terraform/src/executors/apply/schema.d.ts
+++ b/packages/terraform/src/executors/apply/schema.d.ts
@@ -6,4 +6,6 @@ export interface ApplyExecutorSchema {
   lockTimeout?: string
   noColor?: boolean
   parallelism?: number
+  var?: {[key: string]:string}
+  varFile?: string
 }

--- a/packages/terraform/src/executors/plan/executor.ts
+++ b/packages/terraform/src/executors/plan/executor.ts
@@ -16,7 +16,7 @@ function toCmdOptions(options: PlanExecutorSchema ): string[] {
     ...(options.replace !== undefined ? [`-replace=${options.replace}`] : []),
     ...(options.target !== undefined ? [`-target=${options.target}`] : []),
     ...(options.var !== undefined ? Object.entries(options.var).map(([k,v]) => `-var='${k}=${v}'`) : []),
-    ...(options.varFile !== undefined ? [`-var-file=${options.varFile}`] : []),
+    ...(options.varFile !== undefined ? [`-var-file='${options.varFile}'`] : []),
     ...(options.compactWarnings !== undefined ? ['-compact-warnings}'] : []),
     ...(options.detailedExitCode !== undefined ? ['-detailed-exitcode'] : []),
     ...(options.json!== undefined ? ['-json'] : []),


### PR DESCRIPTION
According to spec this is fine https://developer.hashicorp.com/terraform/language/values/variables#variable-definitions-tfvars-files and its missing from the plugin.